### PR TITLE
bindings.gyp: fix byte order on windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   "variables": {
     "bsip_byteorder%":
-      "<!(python -c 'from __future__ import print_function; import sys; print(sys.byteorder)')",
+      "<!(python -c \"from __future__ import print_function; import sys; print(sys.byteorder)\")",
   },
   "targets": [{
     "target_name": "bsip",


### PR DESCRIPTION
`npm install` on windows fails to build because of single quotes in byte order detection.

Fixed by moving to escaping double quotes.

Refs; https://github.com/bcoin-org/bcoin/issues/778